### PR TITLE
Add `pyparsing`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ mo-imports==3.149.20327
 mo-kwargs==4.22.21108
 mo-logs==4.23.21108
 moz-sql-parser==4.40.21126
+pyparsing==3.0.6
 torch==1.8.0+cu111
 torchtext==0.9.0
 transformers==4.5.1


### PR DESCRIPTION
To run the following line

```sh
python sql-to-text/refill/augment_with_pseudo_eng_reps.py
```

`pyparsing` should be installed, but it is not installed via `requrements.txt`. In addition, `pyparsing>=3.0.7` does not work with the refill codebase; `augment_with_pseudo_eng_reps.py` generate an empty list for training and validation datasets.